### PR TITLE
fix: spawn teammates from project root with shared DB

### DIFF
--- a/dist/mcp-server/index.js
+++ b/dist/mcp-server/index.js
@@ -32359,7 +32359,8 @@ function createServer(dbPath) {
 // src/mcp-server/index.ts
 var import_fs2 = require("fs");
 var import_path2 = require("path");
-var dbDir = (0, import_path2.join)(process.cwd(), ".copilot-teams");
+var projectRoot = process.env.COPILOT_TEAMS_PROJECT_ROOT || process.cwd();
+var dbDir = (0, import_path2.join)(projectRoot, ".copilot-teams");
 (0, import_fs2.mkdirSync)(dbDir, { recursive: true });
 var { server, db } = createServer((0, import_path2.join)(dbDir, "teams.db"));
 function shutdown() {

--- a/scripts/spawn-teammate.sh
+++ b/scripts/spawn-teammate.sh
@@ -36,8 +36,9 @@ can_use_tmux() {
 }
 
 if command -v tmux &>/dev/null && can_use_tmux; then
-  WORK_DIR="$(pwd)"
+  PROJECT_ROOT="$(pwd)"
   WORKTREE_INFO=""
+  ADD_DIR_FLAG=""
 
   # Use git worktrees for file isolation when available
   if is_git_repo; then
@@ -47,13 +48,13 @@ if command -v tmux &>/dev/null && can_use_tmux; then
       mkdir -p "$(dirname "$WORKTREE_DIR")"
       if git worktree add "$WORKTREE_DIR" -b "$BRANCH_NAME" 2>/dev/null || \
          git worktree add "$WORKTREE_DIR" "$BRANCH_NAME" 2>/dev/null; then
-        WORK_DIR="$(cd "$WORKTREE_DIR" && pwd)"
+        ADD_DIR_FLAG="--add-dir \"$(cd "$WORKTREE_DIR" && pwd)\""
         WORKTREE_INFO=" with worktree (branch: $BRANCH_NAME)"
       else
         echo "WARNING: worktree creation failed — teammates will share the working directory" >&2
       fi
     else
-      WORK_DIR="$(cd "$WORKTREE_DIR" && pwd)"
+      ADD_DIR_FLAG="--add-dir \"$(cd "$WORKTREE_DIR" && pwd)\""
       WORKTREE_INFO=" with worktree (branch: $BRANCH_NAME)"
     fi
   fi
@@ -61,28 +62,32 @@ if command -v tmux &>/dev/null && can_use_tmux; then
   # Write the prompt to a temp file to avoid quoting issues with special chars
   # in task descriptions (quotes, backticks, dollar signs, etc.) passed through
   # the nested tmux → login-shell → copilot invocation.
+  # Only the inner shell reads and cleans up this file via trap.
   PROMPT_FILE="$(mktemp)"
-  trap 'rm -f "$PROMPT_FILE"' EXIT
   printf '%s\n' "$PROMPT" > "$PROMPT_FILE"
 
-  # Use a login shell (-l) so PATH includes tools installed via nvm, npm global,
-  # homebrew, etc. that are set up in ~/.bashrc / ~/.zshrc. Without -l, "copilot"
-  # may not be found — causing the pane to flash and close instantly.
+  # Launch copilot from the PROJECT ROOT (not the worktree) so that:
+  #   1. The workspace trust prompt is skipped (project root is already trusted)
+  #   2. The MCP server finds the shared .copilot-teams/teams.db
+  # File access to the worktree is granted via --add-dir.
   #
   # copilot -i (--interactive) starts an interactive session and automatically
   # executes the given prompt — the session stays alive for multi-step agent
   # work afterward. Combined with --yolo (auto-approve all tool permissions),
   # this gives the teammate a fully autonomous interactive session.
   #
+  # Use a login shell (-l) so PATH includes tools installed via nvm, npm global,
+  # homebrew, etc. Without -l, "copilot" may not be found.
+  #
   # The trailing echo+read keeps the pane open after copilot exits (whether
   # normally, by crash, or if the binary isn't found) so the user can review
   # output before the pane closes.
   SHELL_CMD="${SHELL:-/bin/bash}"
-  tmux split-window -h -c "$WORK_DIR" \
-    "$SHELL_CMD -lc 'trap \"rm -f $PROMPT_FILE\" EXIT; copilot --agent copilot-agent-teams/teammate --model \"$MODEL\" --yolo -i \"\$(cat \"$PROMPT_FILE\")\"; echo \"[pane exited — press any key to close]\"; read -n1'"
+  tmux split-window -h -c "$PROJECT_ROOT" \
+    "$SHELL_CMD -lc 'export COPILOT_TEAMS_PROJECT_ROOT=\"$PROJECT_ROOT\"; trap \"rm -f $PROMPT_FILE\" EXIT; copilot --agent copilot-agent-teams/teammate --model \"$MODEL\" --yolo $ADD_DIR_FLAG -i \"\$(cat \"$PROMPT_FILE\")\"; echo \"[pane exited — press any key to close]\"; read -n1'"
 
-  tmux select-layout tiled
-  echo "WORK_DIR=$WORK_DIR"
+  tmux select-layout tiled 2>/dev/null || true
+  echo "WORK_DIR=$PROJECT_ROOT"
   echo "Spawned $AGENT_ID in tmux pane${WORKTREE_INFO} (model: $MODEL)"
 else
   echo "NOT_IN_TMUX"

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -3,7 +3,8 @@ import { createServer } from "./server.js";
 import { mkdirSync } from "fs";
 import { join } from "path";
 
-const dbDir = join(process.cwd(), ".copilot-teams");
+const projectRoot = process.env.COPILOT_TEAMS_PROJECT_ROOT || process.cwd();
+const dbDir = join(projectRoot, ".copilot-teams");
 mkdirSync(dbDir, { recursive: true });
 
 const { server, db } = createServer(join(dbDir, "teams.db"));


### PR DESCRIPTION
## Summary
- **Shared DB**: Teammates in worktrees now share the project's `teams.db` via `COPILOT_TEAMS_PROJECT_ROOT` env var, instead of creating empty DBs in their worktree directories
- **Project root launch**: Copilot runs from the trusted project root with `--add-dir` for worktree file access, eliminating the workspace trust prompt
- **Race fix**: Prompt file cleanup moved from outer shell trap to inner shell trap, preventing deletion before the tmux pane reads it

## Test plan
- [x] Dry-run tested: `bash scripts/spawn-teammate.sh test-dry dbg-1 "dry run" gpt-5-mini`
- [x] Verified teammate receives prompt via `-i` flag and auto-executes
- [x] Verified MCP tools (`register_teammate`, `list_tasks`, `create_team`) called successfully
- [x] `npm test` — 112/112 passing
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)